### PR TITLE
Ignore available locales and add English fallback 

### DIFF
--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -18,8 +18,9 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
             next
           else
             text = I18nContent.find_or_create_by!(key: content[:id])
-            Globalize.locale = locale
-            text.update!(value: value)
+            Globalize.with_locale(locale) do
+              text.update!(value: value)
+            end
           end
         end
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,6 @@ class ApplicationController < ActionController::Base
       end
 
       I18n.locale = locale
-      Globalize.locale = I18n.locale
     end
 
     def set_layout

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,9 +47,11 @@ class ApplicationController < ActionController::Base
         session[:locale] = params[:locale]
       end
 
-      session[:locale] ||= I18n.default_locale
-
-      locale = session[:locale]
+      if session[:locale] && I18n.available_locales.include?(session[:locale].to_sym)
+        locale = session[:locale]
+      else
+        locale = I18n.default_locale
+      end
 
       if current_user && current_user.locale != locale.to_s
         current_user.update(locale: locale)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,21 +43,23 @@ class ApplicationController < ActionController::Base
     end
 
     def set_locale
-      if params[:locale] && I18n.available_locales.include?(params[:locale].to_sym)
-        session[:locale] = params[:locale]
+      I18n.locale = current_locale
+
+      if current_user && current_user.locale != I18n.locale.to_s
+        current_user.update(locale: I18n.locale)
       end
 
-      if session[:locale] && I18n.available_locales.include?(session[:locale].to_sym)
-        locale = session[:locale]
+      session[:locale] = I18n.locale
+    end
+
+    def current_locale
+      if I18n.available_locales.include?(params[:locale]&.to_sym)
+        params[:locale]
+      elsif I18n.available_locales.include?(session[:locale]&.to_sym)
+        session[:locale]
       else
-        locale = I18n.default_locale
+        I18n.default_locale
       end
-
-      if current_user && current_user.locale != locale.to_s
-        current_user.update(locale: locale)
-      end
-
-      I18n.locale = locale
     end
 
     def set_layout

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -46,7 +46,6 @@ class Management::BaseController < ActionController::Base
       session[:locale] ||= I18n.default_locale
 
       I18n.locale = session[:locale]
-      Globalize.locale = I18n.locale
     end
 
     def current_budget

--- a/config/initializers/application_custom.rb
+++ b/config/initializers/application_custom.rb
@@ -2,7 +2,9 @@ module Consul
   class Application < Rails::Application
     unless Rails.env.test?
       config.i18n.default_locale = :nl
-      config.i18n.available_locales = ["nl"]
+      config.i18n.available_locales = [:nl]
+      config.i18n.enforce_available_locales = false
+      config.i18n.fallbacks = { nl: :en }
     end
   end
 end

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -88,4 +88,22 @@ describe "Localization" do
       end
     end
   end
+
+  scenario "uses default locale when session locale has disappeared" do
+    default_locales = I18n.available_locales
+
+    visit root_path(locale: :es)
+
+    expect(page).to have_content "Entrar"
+
+    begin
+      I18n.available_locales = default_locales - [:es]
+
+      visit root_path
+
+      expect(page).to have_content "Sign in"
+    ensure
+      I18n.available_locales = default_locales
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,6 @@ RSpec.configure do |config|
   config.before do |example|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
-    Globalize.locale = nil
     Globalize.set_fallbacks_to_all_available_locales
     load Rails.root.join("db", "seeds.rb").to_s
     Setting["feature.user.skip_verification"] = nil


### PR DESCRIPTION
## Objectives

- Always show English translation and avoid showing "missing translation" message.
- Set locale correctly when the value in the cookies is no longer an available locale.
