### PR TITLE
Allow admin see results and stats on expired polls

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -76,6 +76,7 @@ module Abilities
       can [:index, :create, :edit, :update, :destroy], Geozone
 
       can [:read, :create, :update, :destroy, :add_question, :search_booths, :search_officers, :booth_assignments], Poll
+      can [:results, :stats], Poll, ["ends_at < ?", Date.current.beginning_of_day], &:expired?
       can [:read, :create, :update, :destroy, :available], Poll::Booth
       can [:search, :create, :index, :destroy], ::Poll::Officer
       can [:create, :destroy, :manage], ::Poll::BoothAssignment

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -551,8 +551,9 @@ describe "Polls" do
       expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
     end
 
-    scenario "Do not show poll results or stats to admins if disabled" do
-      poll = create(:poll, :expired, results_enabled: false, stats_enabled: false)
+    scenario "Only show poll results or stats to admins if expired" do
+      poll = create(:poll, :current, results_enabled: false, stats_enabled: false)
+      poll_expired = create(:poll, :expired, results_enabled: false, stats_enabled: false)
       admin = create(:administrator).user
 
       login_as admin
@@ -560,6 +561,11 @@ describe "Polls" do
 
       expect(page).not_to have_content("Poll results")
       expect(page).not_to have_content("Participation statistics")
+
+      visit poll_path(poll_expired)
+
+      expect(page).to have_content("Poll results")
+      expect(page).to have_content("Participation statistics")
     end
 
     scenario "Don't show poll results and stats if is not expired" do

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -6,6 +6,8 @@ describe Abilities::Administrator do
 
   let(:user) { administrator.user }
   let(:administrator) { create(:administrator) }
+  let(:poll) { create(:poll, :current, stats_enabled: false, results_enabled: false) }
+  let(:poll_expired) { create(:poll, :expired, stats_enabled: false, results_enabled: false) }
 
   let(:other_user) { create(:user) }
   let(:hidden_user) { create(:user, :hidden) }
@@ -91,6 +93,12 @@ describe Abilities::Administrator do
   it { should be_able_to(:read, Poll::Question) }
   it { should be_able_to(:create, Poll::Question) }
   it { should be_able_to(:update, Poll::Question) }
+
+  it { should_not be_able_to(:stats, poll) }
+  it { should_not be_able_to(:results, poll) }
+
+  it { should be_able_to(:stats, poll_expired) }
+  it { should be_able_to(:results, poll_expired) }
 
   it { is_expected.to be_able_to :manage, Dashboard::AdministratorTask }
   it { is_expected.to be_able_to :manage, dashboard_administrator_task }


### PR DESCRIPTION
## Objectives

- Allow admin to see results and stats on expired polls before publishing results/stats from the admin panel.